### PR TITLE
fix: update yaml3 to prevent panic on empty mapping node in sequence

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0
 	github.com/gorilla/mux v1.8.0
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
-	github.com/oasdiff/yaml v0.0.0-20260316160413-530022a25b2e
-	github.com/oasdiff/yaml3 v0.0.0-20260316155952-42d24df7b091
+	github.com/oasdiff/yaml v0.0.1
+	github.com/oasdiff/yaml3 v0.0.1
 	github.com/perimeterx/marshmallow v1.1.5
 	github.com/stretchr/testify v1.9.0
 	github.com/woodsbury/decimal128 v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0
 	github.com/gorilla/mux v1.8.0
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
-	github.com/oasdiff/yaml v0.0.0-20260313112342-a3ea61cb4d4c
-	github.com/oasdiff/yaml3 v0.0.0-20260224194419-61cd415a242b
+	github.com/oasdiff/yaml v0.0.0-20260316160413-530022a25b2e
+	github.com/oasdiff/yaml3 v0.0.0-20260316155952-42d24df7b091
 	github.com/perimeterx/marshmallow v1.1.5
 	github.com/stretchr/testify v1.9.0
 	github.com/woodsbury/decimal128 v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -18,10 +18,10 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
-github.com/oasdiff/yaml v0.0.0-20260313112342-a3ea61cb4d4c h1:7ACFcSaQsrWtrH4WHHfUqE1C+f8r2uv8KGaW0jTNjus=
-github.com/oasdiff/yaml v0.0.0-20260313112342-a3ea61cb4d4c/go.mod h1:JKox4Gszkxt57kj27u7rvi7IFoIULvCZHUsBTUmQM/s=
-github.com/oasdiff/yaml3 v0.0.0-20260224194419-61cd415a242b h1:vivRhVUAa9t1q0Db4ZmezBP8pWQWnXHFokZj0AOea2g=
-github.com/oasdiff/yaml3 v0.0.0-20260224194419-61cd415a242b/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml v0.0.0-20260316160413-530022a25b2e h1:ggq8bceybJlAyeZNmQnWV1h04Nwcxq3P1CNKFIwzTmc=
+github.com/oasdiff/yaml v0.0.0-20260316160413-530022a25b2e/go.mod h1:9BgjwzmYck7y58Uph7CTOIHpxrQyLLuWDiU29paDzNU=
+github.com/oasdiff/yaml3 v0.0.0-20260316155952-42d24df7b091 h1:9BhI2ddVLDF7hbq1NZNF7jZDjRGxBzLLCrpw349pV6o=
+github.com/oasdiff/yaml3 v0.0.0-20260316155952-42d24df7b091/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -18,10 +18,10 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
-github.com/oasdiff/yaml v0.0.0-20260316160413-530022a25b2e h1:ggq8bceybJlAyeZNmQnWV1h04Nwcxq3P1CNKFIwzTmc=
-github.com/oasdiff/yaml v0.0.0-20260316160413-530022a25b2e/go.mod h1:9BgjwzmYck7y58Uph7CTOIHpxrQyLLuWDiU29paDzNU=
-github.com/oasdiff/yaml3 v0.0.0-20260316155952-42d24df7b091 h1:9BhI2ddVLDF7hbq1NZNF7jZDjRGxBzLLCrpw349pV6o=
-github.com/oasdiff/yaml3 v0.0.0-20260316155952-42d24df7b091/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml v0.0.1 h1:dPrn0F2PJ7HdzHPndJkArvB2Fw0cwgFdVUKCEkoFuds=
+github.com/oasdiff/yaml v0.0.1/go.mod h1:r8bgVgpWT5iIN/AgP0GljFvB6CicK+yL1nIAbm+8/QQ=
+github.com/oasdiff/yaml3 v0.0.1 h1:kReOSraQLTxuuGNX9aNeJ7tcsvUB2MS+iupdUrWe4Z0=
+github.com/oasdiff/yaml3 v0.0.1/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Summary
- Bumps `oasdiff/yaml3` and `oasdiff/yaml` to fix a panic (`index out of range [0] with length 0`) when loading a spec that contains a YAML sequence with an empty mapping node (e.g. `- {}`)
- Root fix: added `len(n.Content) == 0` guard in `addOriginInSeq` in `oasdiff/yaml3`

## Test plan
- [ ] Regression test `TestOrigin_SequenceOfEmptyMaps` added in `oasdiff/yaml3`
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)