### PR TITLE
fix: rename module path to github.com/oasdiff/kin-openapi

### DIFF
--- a/.github/docs/openapi2.txt
+++ b/.github/docs/openapi2.txt
@@ -1,4 +1,4 @@
-package openapi2 // import "github.com/getkin/kin-openapi/openapi2"
+package openapi2 // import "github.com/oasdiff/kin-openapi/openapi2"
 
 Package openapi2 parses and writes OpenAPIv2 specification documents.
 

--- a/.github/docs/openapi2conv.txt
+++ b/.github/docs/openapi2conv.txt
@@ -1,4 +1,4 @@
-package openapi2conv // import "github.com/getkin/kin-openapi/openapi2conv"
+package openapi2conv // import "github.com/oasdiff/kin-openapi/openapi2conv"
 
 Package openapi2conv converts an OpenAPI v2 specification document to v3.
 

--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -1,4 +1,4 @@
-package openapi3 // import "github.com/getkin/kin-openapi/openapi3"
+package openapi3 // import "github.com/oasdiff/kin-openapi/openapi3"
 
 Package openapi3 parses and writes OpenAPI 3 specification documents.
 

--- a/.github/docs/openapi3filter.txt
+++ b/.github/docs/openapi3filter.txt
@@ -1,4 +1,4 @@
-package openapi3filter // import "github.com/getkin/kin-openapi/openapi3filter"
+package openapi3filter // import "github.com/oasdiff/kin-openapi/openapi3filter"
 
 Package openapi3filter validates that requests and inputs request an OpenAPI 3
 specification file.

--- a/.github/docs/openapi3gen.txt
+++ b/.github/docs/openapi3gen.txt
@@ -1,4 +1,4 @@
-package openapi3gen // import "github.com/getkin/kin-openapi/openapi3gen"
+package openapi3gen // import "github.com/oasdiff/kin-openapi/openapi3gen"
 
 Package openapi3gen generates OpenAPIv3 JSON schemas from Go types.
 

--- a/.github/docs/routers.txt
+++ b/.github/docs/routers.txt
@@ -1,4 +1,4 @@
-package routers // import "github.com/getkin/kin-openapi/routers"
+package routers // import "github.com/oasdiff/kin-openapi/routers"
 
 
 VARIABLES

--- a/.github/docs/routers_gorillamux.txt
+++ b/.github/docs/routers_gorillamux.txt
@@ -1,4 +1,4 @@
-package gorillamux // import "github.com/getkin/kin-openapi/routers/gorillamux"
+package gorillamux // import "github.com/oasdiff/kin-openapi/routers/gorillamux"
 
 Package gorillamux implements a router.
 

--- a/.github/docs/routers_legacy.txt
+++ b/.github/docs/routers_legacy.txt
@@ -1,4 +1,4 @@
-package legacy // import "github.com/getkin/kin-openapi/routers/legacy"
+package legacy // import "github.com/oasdiff/kin-openapi/routers/legacy"
 
 Package legacy implements a router.
 

--- a/.github/docs/routers_legacy_pathpattern.txt
+++ b/.github/docs/routers_legacy_pathpattern.txt
@@ -1,4 +1,4 @@
-package pathpattern // import "github.com/getkin/kin-openapi/routers/legacy/pathpattern"
+package pathpattern // import "github.com/oasdiff/kin-openapi/routers/legacy/pathpattern"
 
 Package pathpattern implements path matching.
 

--- a/README.md
+++ b/README.md
@@ -294,6 +294,9 @@ for _, path := range doc.Paths.InMatchingOrder() {
 
 ## CHANGELOG: Sub-v1 breaking API changes
 
+### v0.136.0
+* Module renamed from `github.com/getkin/kin-openapi` to `github.com/oasdiff/kin-openapi`. Update all imports accordingly: `openapi2`, `openapi2conv`, `openapi3`, `openapi3filter`, `openapi3gen`, `routers`, `routers/gorillamux`, `routers/legacy`, `routers/legacy/pathpattern`
+
 ### v0.135.0
 * `openapi3.MediaType.Encoding` field type changed from `map[string]*Encoding` to `Encodings`
 * `openapi3.Server.Variables` field type changed from `map[string]*ServerVariable` to `ServerVariables`

--- a/cmd/validate/main.go
+++ b/cmd/validate/main.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/oasdiff/yaml"
 
-	"github.com/getkin/kin-openapi/openapi2"
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi2"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 var (
@@ -36,7 +36,7 @@ func main() {
 	flag.Parse()
 	filename := flag.Arg(0)
 	if len(flag.Args()) != 1 || filename == "" {
-		log.Fatalf("Usage: go run github.com/getkin/kin-openapi/cmd/validate@latest [--circular] [--defaults] [--examples] [--ext] [--patterns] -- <local YAML or JSON file>\nGot: %+v\n", os.Args)
+		log.Fatalf("Usage: go run github.com/oasdiff/kin-openapi/cmd/validate@latest [--circular] [--defaults] [--examples] [--ext] [--patterns] -- <local YAML or JSON file>\nGot: %+v\n", os.Args)
 	}
 
 	data, err := os.ReadFile(filename)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/getkin/kin-openapi
+module github.com/oasdiff/kin-openapi
 
 go 1.22.5
 

--- a/openapi2/marsh.go
+++ b/openapi2/marsh.go
@@ -19,7 +19,7 @@ func unmarshalError(jsonUnmarshalErr error) error {
 func unmarshal(data []byte, v any) error {
 	var jsonErr, yamlErr error
 
-	// See https://github.com/getkin/kin-openapi/issues/680
+	// See https://github.com/oasdiff/kin-openapi/issues/680
 	if jsonErr = json.Unmarshal(data, v); jsonErr == nil {
 		return nil
 	}

--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -3,7 +3,7 @@ package openapi2
 import (
 	"encoding/json"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // T is the root of an OpenAPI v2 document

--- a/openapi2/openapi2_test.go
+++ b/openapi2/openapi2_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/oasdiff/yaml"
 
-	"github.com/getkin/kin-openapi/openapi2"
+	"github.com/oasdiff/kin-openapi/openapi2"
 )
 
 func Example() {

--- a/openapi2/operation.go
+++ b/openapi2/operation.go
@@ -3,7 +3,7 @@ package openapi2
 import (
 	"encoding/json"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 type Operation struct {

--- a/openapi2/parameter.go
+++ b/openapi2/parameter.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"sort"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 type Parameters []*Parameter

--- a/openapi2/path_item.go
+++ b/openapi2/path_item.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 type PathItem struct {

--- a/openapi2/response.go
+++ b/openapi2/response.go
@@ -3,7 +3,7 @@ package openapi2
 import (
 	"encoding/json"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 type Response struct {

--- a/openapi2/schema.go
+++ b/openapi2/schema.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 type (
@@ -260,7 +260,7 @@ func (schema *Schema) UnmarshalJSON(data []byte) error {
 	*schema = Schema(x)
 
 	if schema.Format == "date" {
-		// This is a fix for: https://github.com/getkin/kin-openapi/issues/697
+		// This is a fix for: https://github.com/oasdiff/kin-openapi/issues/697
 		if eg, ok := schema.Example.(string); ok {
 			schema.Example = strings.TrimSuffix(eg, "T00:00:00Z")
 		}

--- a/openapi2/security_scheme.go
+++ b/openapi2/security_scheme.go
@@ -3,7 +3,7 @@ package openapi2
 import (
 	"encoding/json"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 type SecurityRequirements []map[string][]string

--- a/openapi2conv/issue1016_test.go
+++ b/openapi2conv/issue1016_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi2"
+	"github.com/oasdiff/kin-openapi/openapi2"
 	"github.com/stretchr/testify/require"
 )
 

--- a/openapi2conv/issue1069_test.go
+++ b/openapi2conv/issue1069_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi2"
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi2"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/oasdiff/yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/openapi2conv/issue1091_test.go
+++ b/openapi2conv/issue1091_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi2"
+	"github.com/oasdiff/kin-openapi/openapi2"
 )
 
 func TestIssue1091_PropertyExtensions(t *testing.T) {

--- a/openapi2conv/issue187_test.go
+++ b/openapi2conv/issue187_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/oasdiff/yaml"
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi2"
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi2"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func v2v3JSON(spec2 []byte) (doc3 *openapi3.T, err error) {

--- a/openapi2conv/issue440_test.go
+++ b/openapi2conv/issue440_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi2"
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi2"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func TestIssue440(t *testing.T) {

--- a/openapi2conv/issue979_test.go
+++ b/openapi2conv/issue979_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi2"
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi2"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func TestIssue979(t *testing.T) {

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi2"
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi2"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ToV3 converts an OpenAPIv2 spec to an OpenAPIv3 spec

--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi2"
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi2"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func TestConvOpenAPIV3ToV2(t *testing.T) {

--- a/openapi3/additionalProperties_test.go
+++ b/openapi3/additionalProperties_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/oasdiff/yaml3"
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func TestMarshalAdditionalProperties(t *testing.T) {

--- a/openapi3/example_refs_test.go
+++ b/openapi3/example_refs_test.go
@@ -3,7 +3,7 @@ package openapi3_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 	"github.com/stretchr/testify/require"
 )
 

--- a/openapi3/issue241_test.go
+++ b/openapi3/issue241_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/oasdiff/yaml3"
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func TestIssue241(t *testing.T) {

--- a/openapi3/issue513_test.go
+++ b/openapi3/issue513_test.go
@@ -34,7 +34,7 @@ paths:
 `[1:])
 
 	// When that site fails to respond:
-	// see https://github.com/getkin/kin-openapi/issues/495
+	// see https://github.com/oasdiff/kin-openapi/issues/495
 
 	// http://schemas.sentex.io/store/categories.json
 	// {

--- a/openapi3/issue594_test.go
+++ b/openapi3/issue594_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func TestIssue594(t *testing.T) {

--- a/openapi3/issue615_test.go
+++ b/openapi3/issue615_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func TestIssue615(t *testing.T) {

--- a/openapi3/issue652_test.go
+++ b/openapi3/issue652_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func TestIssue652(t *testing.T) {

--- a/openapi3/issue657_test.go
+++ b/openapi3/issue657_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func TestOneOf_Warning_Errors(t *testing.T) {

--- a/openapi3/issue689_test.go
+++ b/openapi3/issue689_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func TestIssue689(t *testing.T) {

--- a/openapi3/issue735_test.go
+++ b/openapi3/issue735_test.go
@@ -155,7 +155,7 @@ func TestIssue735(t *testing.T) {
 			value:            map[string]any{"foo": 42},
 			extraNotContains: []any{42},
 		},
-		// TODO: uncomment when https://github.com/getkin/kin-openapi/issues/502 is fixed
+		// TODO: uncomment when https://github.com/oasdiff/kin-openapi/issues/502 is fixed
 		//{
 		//	name: "read only properties",
 		//	schema: NewSchema().WithProperties(map[string]*Schema{

--- a/openapi3/issue767_test.go
+++ b/openapi3/issue767_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func TestIssue767(t *testing.T) {

--- a/openapi3/issue883_test.go
+++ b/openapi3/issue883_test.go
@@ -7,7 +7,7 @@ import (
 	yamlv3 "github.com/oasdiff/yaml3"
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func TestIssue883(t *testing.T) {

--- a/openapi3/load_cicular_ref_with_external_file_test.go
+++ b/openapi3/load_cicular_ref_with_external_file_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 //go:embed testdata/circularRef/*

--- a/openapi3/load_with_go_embed_test.go
+++ b/openapi3/load_with_go_embed_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 //go:embed testdata/recursiveRef/*

--- a/openapi3/marsh.go
+++ b/openapi3/marsh.go
@@ -20,7 +20,7 @@ func unmarshalError(jsonUnmarshalErr error) error {
 func unmarshal(data []byte, v any, includeOrigin bool, location *url.URL) error {
 	var jsonErr, yamlErr error
 
-	// See https://github.com/getkin/kin-openapi/issues/680
+	// See https://github.com/oasdiff/kin-openapi/issues/680
 	if jsonErr = json.Unmarshal(data, v); jsonErr == nil {
 		return nil
 	}

--- a/openapi3/race_test.go
+++ b/openapi3/race_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func TestRaceyPatternSchemaValidateHindersIt(t *testing.T) {

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -476,7 +476,7 @@ func (schema *Schema) UnmarshalJSON(data []byte) error {
 	schema.Example = stripOriginFromAny(schema.Example)
 
 	if schema.Format == "date" {
-		// This is a fix for: https://github.com/getkin/kin-openapi/issues/697
+		// This is a fix for: https://github.com/oasdiff/kin-openapi/issues/697
 		if eg, ok := schema.Example.(string); ok {
 			schema.Example = strings.TrimSuffix(eg, "T00:00:00Z")
 		}
@@ -1211,7 +1211,7 @@ func (schema *Schema) visitJSON(settings *schemaValidationSettings, value any) (
 		return schema.visitJSONArray(settings, value)
 	case map[string]any:
 		return schema.visitJSONObject(settings, value)
-	case map[any]any: // for YAML cf. issue https://github.com/getkin/kin-openapi/issues/444
+	case map[any]any: // for YAML cf. issue https://github.com/oasdiff/kin-openapi/issues/444
 		values := make(map[string]any, len(value))
 		for key, v := range value {
 			if k, ok := key.(string); ok {

--- a/openapi3/schema_validation_settings_test.go
+++ b/openapi3/schema_validation_settings_test.go
@@ -3,7 +3,7 @@ package openapi3_test
 import (
 	"fmt"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func ExampleSetSchemaErrorMessageCustomizer() {

--- a/openapi3/unique_items_checker_test.go
+++ b/openapi3/unique_items_checker_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func TestRegisterArrayUniqueItemsChecker(t *testing.T) {

--- a/openapi3/validation_issue409_test.go
+++ b/openapi3/validation_issue409_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func TestIssue409PatternIgnored(t *testing.T) {

--- a/openapi3filter/authentication_input.go
+++ b/openapi3filter/authentication_input.go
@@ -3,7 +3,7 @@ package openapi3filter
 import (
 	"fmt"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 type AuthenticationInput struct {

--- a/openapi3filter/csv_file_upload_test.go
+++ b/openapi3filter/csv_file_upload_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func TestValidateCsvFileUpload(t *testing.T) {

--- a/openapi3filter/errors.go
+++ b/openapi3filter/errors.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 var _ error = &RequestError{}

--- a/openapi3filter/issue1045_test.go
+++ b/openapi3filter/issue1045_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func TestIssue1045(t *testing.T) {

--- a/openapi3filter/issue1110_test.go
+++ b/openapi3filter/issue1110_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func TestIssue1110(t *testing.T) {

--- a/openapi3filter/issue201_test.go
+++ b/openapi3filter/issue201_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func TestIssue201(t *testing.T) {

--- a/openapi3filter/issue267_test.go
+++ b/openapi3filter/issue267_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func TestIssue267(t *testing.T) {

--- a/openapi3filter/issue436_test.go
+++ b/openapi3filter/issue436_test.go
@@ -9,9 +9,9 @@ import (
 	"net/textproto"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func Example_validateMultipartFormData() {

--- a/openapi3filter/issue624_test.go
+++ b/openapi3filter/issue624_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func TestIssue624(t *testing.T) {

--- a/openapi3filter/issue625_test.go
+++ b/openapi3filter/issue625_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func TestIssue625(t *testing.T) {

--- a/openapi3filter/issue639_test.go
+++ b/openapi3filter/issue639_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func TestIssue639(t *testing.T) {

--- a/openapi3filter/issue641_test.go
+++ b/openapi3filter/issue641_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func TestIssue641(t *testing.T) {

--- a/openapi3filter/issue689_test.go
+++ b/openapi3filter/issue689_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func TestIssue689(t *testing.T) {

--- a/openapi3filter/issue707_test.go
+++ b/openapi3filter/issue707_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func TestIssue707(t *testing.T) {

--- a/openapi3filter/issue722_test.go
+++ b/openapi3filter/issue722_test.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func TestValidateMultipartFormDataContainingAllOf(t *testing.T) {

--- a/openapi3filter/issue733_test.go
+++ b/openapi3filter/issue733_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func TestIntMax(t *testing.T) {

--- a/openapi3filter/issue743_test.go
+++ b/openapi3filter/issue743_test.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -72,7 +72,7 @@ security:
 				AuthenticationFunc: func(ctx context.Context, ai *openapi3filter.AuthenticationInput) error {
 					defer req.Body.Close()
 
-					// NOTE that reading from `req.Body` appears to trigger the underlying issue raised in https://github.com/getkin/kin-openapi/issues/743
+					// NOTE that reading from `req.Body` appears to trigger the underlying issue raised in https://github.com/oasdiff/kin-openapi/issues/743
 					// this doesn't seem to occur when using `req.GetBody()`, but as that's less common to do, we should support both types
 					body, err := io.ReadAll(ai.RequestValidationInput.Request.Body)
 					assert.NoError(t, err)
@@ -131,7 +131,7 @@ security:
 	authenticatorFunc := func(ctx context.Context, ai *openapi3filter.AuthenticationInput) error {
 		defer ai.RequestValidationInput.Request.Body.Close()
 
-		// NOTE that reading from `req.Body` appears to trigger the underlying issue raised in https://github.com/getkin/kin-openapi/issues/743
+		// NOTE that reading from `req.Body` appears to trigger the underlying issue raised in https://github.com/oasdiff/kin-openapi/issues/743
 		// this doesn't seem to occur when using `req.GetBody()`, but as that's less common to do, we should support both types
 		body, err := io.ReadAll(ai.RequestValidationInput.Request.Body)
 		assert.NoError(t, err)

--- a/openapi3filter/issue789_test.go
+++ b/openapi3filter/issue789_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func TestIssue789(t *testing.T) {

--- a/openapi3filter/issue884_test.go
+++ b/openapi3filter/issue884_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func TestIssue884(t *testing.T) {

--- a/openapi3filter/issue949_test.go
+++ b/openapi3filter/issue949_test.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 	"github.com/stretchr/testify/require"
 )
 

--- a/openapi3filter/middleware.go
+++ b/openapi3filter/middleware.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/getkin/kin-openapi/routers"
+	"github.com/oasdiff/kin-openapi/routers"
 )
 
 // Validator provides HTTP request and response validation middleware.

--- a/openapi3filter/middleware_test.go
+++ b/openapi3filter/middleware_test.go
@@ -16,9 +16,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 const validatorSpec = `

--- a/openapi3filter/options.go
+++ b/openapi3filter/options.go
@@ -1,6 +1,6 @@
 package openapi3filter
 
-import "github.com/getkin/kin-openapi/openapi3"
+import "github.com/oasdiff/kin-openapi/openapi3"
 
 // Options used by ValidateRequest and ValidateResponse
 type Options struct {

--- a/openapi3filter/options_test.go
+++ b/openapi3filter/options_test.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func ExampleOptions_WithCustomSchemaErrorFunc() {

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -19,7 +19,7 @@ import (
 
 	yaml "github.com/oasdiff/yaml3"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ParseErrorKind describes a kind of ParseError.

--- a/openapi3filter/req_resp_decoder_test.go
+++ b/openapi3filter/req_resp_decoder_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	legacyrouter "github.com/getkin/kin-openapi/routers/legacy"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	legacyrouter "github.com/oasdiff/kin-openapi/routers/legacy"
 )
 
 var (

--- a/openapi3filter/testdata/issue1100_test.go
+++ b/openapi3filter/testdata/issue1100_test.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3filter"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func TestIssue1100(t *testing.T) {

--- a/openapi3filter/unpack_errors_test.go
+++ b/openapi3filter/unpack_errors_test.go
@@ -7,9 +7,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func Example() {

--- a/openapi3filter/upload_arbitrary_file_test.go
+++ b/openapi3filter/upload_arbitrary_file_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func TestValidateUploadArbitraryBinaryFile(t *testing.T) {

--- a/openapi3filter/validate_readonly_test.go
+++ b/openapi3filter/validate_readonly_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	legacyrouter "github.com/getkin/kin-openapi/routers/legacy"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	legacyrouter "github.com/oasdiff/kin-openapi/routers/legacy"
 )
 
 func TestReadOnlyWriteOnlyPropertiesValidation(t *testing.T) {

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ErrAuthenticationServiceMissing is returned when no authentication service

--- a/openapi3filter/validate_request_example_test.go
+++ b/openapi3filter/validate_request_example_test.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func ExampleAuthenticationFunc() {

--- a/openapi3filter/validate_request_input.go
+++ b/openapi3filter/validate_request_input.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers"
 )
 
 // A ContentParameterDecoder takes a parameter definition from the OpenAPI spec,

--- a/openapi3filter/validate_request_test.go
+++ b/openapi3filter/validate_request_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
-	legacyrouter "github.com/getkin/kin-openapi/routers/legacy"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
+	legacyrouter "github.com/oasdiff/kin-openapi/routers/legacy"
 )
 
 func setupTestRouter(t *testing.T, spec string) routers.Router {

--- a/openapi3filter/validate_response.go
+++ b/openapi3filter/validate_response.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // ValidateResponse is used to validate the given input according to previous

--- a/openapi3filter/validate_response_test.go
+++ b/openapi3filter/validate_response_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 func Test_validateResponseHeader(t *testing.T) {

--- a/openapi3filter/validate_set_default_test.go
+++ b/openapi3filter/validate_set_default_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	legacyrouter "github.com/getkin/kin-openapi/routers/legacy"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	legacyrouter "github.com/oasdiff/kin-openapi/routers/legacy"
 )
 
 func TestValidatingRequestParameterAndSetDefault(t *testing.T) {

--- a/openapi3filter/validation_discriminator_test.go
+++ b/openapi3filter/validation_discriminator_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	legacyrouter "github.com/getkin/kin-openapi/routers/legacy"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	legacyrouter "github.com/oasdiff/kin-openapi/routers/legacy"
 )
 
 func TestValidationWithDiscriminatorSelection(t *testing.T) {

--- a/openapi3filter/validation_enum_test.go
+++ b/openapi3filter/validation_enum_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	legacyrouter "github.com/getkin/kin-openapi/routers/legacy"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	legacyrouter "github.com/oasdiff/kin-openapi/routers/legacy"
 )
 
 func TestValidationWithIntegerEnum(t *testing.T) {

--- a/openapi3filter/validation_error_encoder.go
+++ b/openapi3filter/validation_error_encoder.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers"
 )
 
 // ValidationErrorEncoder wraps a base ErrorEncoder to handle ValidationErrors

--- a/openapi3filter/validation_error_test.go
+++ b/openapi3filter/validation_error_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers"
 )
 
 func newPetstoreRequest(t *testing.T, method, path string, body io.Reader) *http.Request {

--- a/openapi3filter/validation_handler.go
+++ b/openapi3filter/validation_handler.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers"
-	legacyrouter "github.com/getkin/kin-openapi/routers/legacy"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers"
+	legacyrouter "github.com/oasdiff/kin-openapi/routers/legacy"
 )
 
 // AuthenticationFunc allows for custom security requirement validation.

--- a/openapi3filter/validation_test.go
+++ b/openapi3filter/validation_test.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	legacyrouter "github.com/getkin/kin-openapi/routers/legacy"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	legacyrouter "github.com/oasdiff/kin-openapi/routers/legacy"
 )
 
 type ExampleRequest struct {

--- a/openapi3filter/zip_file_upload_test.go
+++ b/openapi3filter/zip_file_upload_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func TestValidateZipFileUpload(t *testing.T) {

--- a/openapi3gen/openapi3gen.go
+++ b/openapi3gen/openapi3gen.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // CycleError indicates that a type graph has one or more possible cycles.

--- a/openapi3gen/openapi3gen_newschemarefforvalue_test.go
+++ b/openapi3gen/openapi3gen_newschemarefforvalue_test.go
@@ -6,9 +6,9 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3gen"
-	"github.com/getkin/kin-openapi/openapi3gen/internal/subpkg"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3gen"
+	"github.com/oasdiff/kin-openapi/openapi3gen/internal/subpkg"
 )
 
 // Make sure that custom schema name generator is employed and results produced with it are properly used

--- a/openapi3gen/openapi3gen_test.go
+++ b/openapi3gen/openapi3gen_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3gen"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3gen"
 )
 
 func ExampleGenerator_SchemaRefs() {
@@ -330,7 +330,7 @@ func TestEmbeddedPointerStructs(t *testing.T) {
 	require.Equal(t, true, ok)
 }
 
-// See: https://github.com/getkin/kin-openapi/issues/500
+// See: https://github.com/oasdiff/kin-openapi/issues/500
 func TestEmbeddedPointerStructsWithSchemaCustomizer(t *testing.T) {
 	type EmbeddedStruct struct {
 		ID string

--- a/openapi3gen/simple_test.go
+++ b/openapi3gen/simple_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/getkin/kin-openapi/openapi3gen"
+	"github.com/oasdiff/kin-openapi/openapi3gen"
 )
 
 type (

--- a/routers/gorillamux/example_test.go
+++ b/routers/gorillamux/example_test.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
 )
 
 func Example() {

--- a/routers/gorillamux/router.go
+++ b/routers/gorillamux/router.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers"
 )
 
 var _ routers.Router = &Router{}
@@ -151,7 +151,7 @@ func makeServers(in openapi3.Servers) ([]srv, error) {
 		// then url.Parse() cannot parse "http://domain.tld:`bEncode({port})`/bla"
 		// and mux is not able to set the {port} variable
 		// So we just use the default value for this variable.
-		// See https://github.com/getkin/kin-openapi/issues/367
+		// See https://github.com/oasdiff/kin-openapi/issues/367
 		var varsUpdater varsf
 		if lhs := strings.Index(serverURL, ":{"); lhs > 0 {
 			rest := serverURL[lhs+len(":{"):]

--- a/routers/gorillamux/router_test.go
+++ b/routers/gorillamux/router_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers"
 )
 
 func TestRouter(t *testing.T) {

--- a/routers/issue356_test.go
+++ b/routers/issue356_test.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/getkin/kin-openapi/routers"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
-	"github.com/getkin/kin-openapi/routers/legacy"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	"github.com/oasdiff/kin-openapi/routers"
+	"github.com/oasdiff/kin-openapi/routers/gorillamux"
+	"github.com/oasdiff/kin-openapi/routers/legacy"
 )
 
 func TestIssue356(t *testing.T) {

--- a/routers/legacy/issue444_test.go
+++ b/routers/legacy/issue444_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	legacyrouter "github.com/getkin/kin-openapi/routers/legacy"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	legacyrouter "github.com/oasdiff/kin-openapi/routers/legacy"
 )
 
 func TestIssue444(t *testing.T) {

--- a/routers/legacy/router.go
+++ b/routers/legacy/router.go
@@ -13,9 +13,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers"
-	"github.com/getkin/kin-openapi/routers/legacy/pathpattern"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers"
+	"github.com/oasdiff/kin-openapi/routers/legacy/pathpattern"
 )
 
 // Routers maps a HTTP request to a Router.

--- a/routers/legacy/router_test.go
+++ b/routers/legacy/router_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/routers"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/routers"
 )
 
 func TestRouter(t *testing.T) {

--- a/routers/legacy/validate_request_test.go
+++ b/routers/legacy/validate_request_test.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/getkin/kin-openapi/routers/legacy"
+	"github.com/oasdiff/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3filter"
+	"github.com/oasdiff/kin-openapi/routers/legacy"
 )
 
 const spec = `

--- a/routers/types.go
+++ b/routers/types.go
@@ -3,7 +3,7 @@ package routers
 import (
 	"net/http"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/kin-openapi/openapi3"
 )
 
 // Router helps link http.Request.s and an OpenAPIv3 spec


### PR DESCRIPTION
## Summary
- Renames the module path from `github.com/getkin/kin-openapi` to `github.com/oasdiff/kin-openapi`
- Allows consumers to depend on this fork directly without a `replace` directive, fixing `go install` failures ([oasdiff/oasdiff#810](https://github.com/oasdiff/oasdiff/issues/810))
- All import paths in 106 files updated accordingly

## Test plan
- [x] All existing tests pass
- [x] `docs.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)