### PR TITLE
fix: strip `__origin__` from slices in example values

### DIFF
--- a/openapi3/origin.go
+++ b/openapi3/origin.go
@@ -26,13 +26,19 @@ type Location struct {
 // dedicated UnmarshalJSON to consume the origin metadata injected by
 // the YAML origin-tracking loader.
 func stripOriginFromAny(v any) any {
-	m, ok := v.(map[string]any)
-	if !ok {
+	switch x := v.(type) {
+	case map[string]any:
+		delete(x, originKey)
+		for k, val := range x {
+			x[k] = stripOriginFromAny(val)
+		}
+		return x
+	case []any:
+		for i, val := range x {
+			x[i] = stripOriginFromAny(val)
+		}
+		return x
+	default:
 		return v
 	}
-	delete(m, originKey)
-	for k, val := range m {
-		m[k] = stripOriginFromAny(val)
-	}
-	return m
 }

--- a/openapi3/origin_test.go
+++ b/openapi3/origin_test.go
@@ -436,6 +436,53 @@ func TestOrigin_XML(t *testing.T) {
 		base.Origin.Fields["prefix"])
 }
 
+func TestStripOriginFromAny_Slice(t *testing.T) {
+	// Simulates what the YAML origin-tracking loader produces for example
+	// values that contain arrays of objects.
+	input := map[string]any{
+		"name": "test",
+		"items": []any{
+			map[string]any{
+				"__origin__": map[string]any{"file": "a.yaml", "line": 1},
+				"id":         1,
+			},
+			map[string]any{
+				"__origin__": map[string]any{"file": "a.yaml", "line": 2},
+				"id":         2,
+			},
+		},
+	}
+
+	result := stripOriginFromAny(input)
+	m := result.(map[string]any)
+	items := m["items"].([]any)
+	for _, item := range items {
+		itemMap := item.(map[string]any)
+		require.NotContains(t, itemMap, "__origin__")
+	}
+}
+
+func TestOrigin_ExampleWithArrayValue(t *testing.T) {
+	loader := NewLoader()
+
+	IncludeOrigin = true
+	defer unsetIncludeOrigin()
+
+	doc, err := loader.LoadFromFile("testdata/origin/example_with_array.yaml")
+	require.NoError(t, err)
+
+	example := doc.Paths.Find("/subscribe").Post.RequestBody.Value.Content["application/json"].Examples["bar"]
+	require.NotNil(t, example.Value)
+
+	// The example value contains a list of objects; __origin__ must be stripped from each.
+	value := example.Value.Value.(map[string]any)
+	items := value["items"].([]any)
+	for _, item := range items {
+		itemMap := item.(map[string]any)
+		require.NotContains(t, itemMap, "__origin__")
+	}
+}
+
 // TestOrigin_OriginExistsInProperties verifies that loading fails when a specification
 // contains a property named "__origin__", highlighting a limitation in the current implementation.
 func TestOrigin_OriginExistsInProperties(t *testing.T) {

--- a/openapi3/testdata/origin/example_with_array.yaml
+++ b/openapi3/testdata/origin/example_with_array.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+  title: Example with Array Value
+  version: 1.0.0
+paths:
+  /subscribe:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+            examples:
+              bar:
+                summary: A bar example with array
+                value:
+                  name: test
+                  items:
+                    - id: 1
+                      label: first
+                    - id: 2
+                      label: second
+      responses:
+        "200":
+          description: OK


### PR DESCRIPTION
## Summary

- `stripOriginFromAny` only recursed into `map[string]any` but not `[]any` slices
- This caused `__origin__` keys inside array elements to survive stripping
- Affects example values containing lists of objects (e.g. a multiple request/response examples with arrays)
- This in turn causes `oasdiff diff` to report false positive diffs when comparing identical specs loaded from different file paths (follow-up to #1132)

## Fix

Extend the `switch` in `stripOriginFromAny` to also handle `[]any`, recursing into each element.

## Test plan

- [x] `TestStripOriginFromAny_Slice`: unit test that verifies `__origin__` is stripped from objects inside slices
- [x] `TestOrigin_ExampleWithArrayValue`: integration test that loads a spec with array-valued examples and verifies `__origin__` is stripped
- [x] All existing tests pass: `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)