### PR TITLE
fix: strip __origin__ from extension values to prevent spurious diffs

### DIFF
--- a/openapi3/components.go
+++ b/openapi3/components.go
@@ -96,6 +96,7 @@ func (components *Components) UnmarshalJSON(data []byte) error {
 	}
 	_ = json.Unmarshal(data, &x.Extensions)
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "schemas")
 	delete(x.Extensions, "parameters")
 	delete(x.Extensions, "headers")

--- a/openapi3/contact.go
+++ b/openapi3/contact.go
@@ -53,6 +53,7 @@ func (contact *Contact) UnmarshalJSON(data []byte) error {
 	_ = json.Unmarshal(data, &x.Extensions)
 
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "name")
 	delete(x.Extensions, "url")
 	delete(x.Extensions, "email")

--- a/openapi3/discriminator.go
+++ b/openapi3/discriminator.go
@@ -61,6 +61,7 @@ func (discriminator *Discriminator) UnmarshalJSON(data []byte) error {
 	_ = json.Unmarshal(data, &x.Extensions)
 
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "propertyName")
 	delete(x.Extensions, "mapping")
 	if len(x.Extensions) == 0 {

--- a/openapi3/encoding.go
+++ b/openapi3/encoding.go
@@ -92,6 +92,7 @@ func (encoding *Encoding) UnmarshalJSON(data []byte) error {
 	_ = json.Unmarshal(data, &x.Extensions)
 
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "contentType")
 	delete(x.Extensions, "headers")
 	delete(x.Extensions, "style")

--- a/openapi3/example.go
+++ b/openapi3/example.go
@@ -61,6 +61,7 @@ func (example *Example) UnmarshalJSON(data []byte) error {
 	}
 	_ = json.Unmarshal(data, &x.Extensions)
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "summary")
 	delete(x.Extensions, "description")
 	delete(x.Extensions, "value")

--- a/openapi3/external_docs.go
+++ b/openapi3/external_docs.go
@@ -51,6 +51,7 @@ func (e *ExternalDocs) UnmarshalJSON(data []byte) error {
 	}
 	_ = json.Unmarshal(data, &x.Extensions)
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "description")
 	delete(x.Extensions, "url")
 	if len(x.Extensions) == 0 {

--- a/openapi3/info.go
+++ b/openapi3/info.go
@@ -64,6 +64,7 @@ func (info *Info) UnmarshalJSON(data []byte) error {
 	}
 	_ = json.Unmarshal(data, &x.Extensions)
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "title")
 	delete(x.Extensions, "description")
 	delete(x.Extensions, "termsOfService")

--- a/openapi3/license.go
+++ b/openapi3/license.go
@@ -47,6 +47,7 @@ func (license *License) UnmarshalJSON(data []byte) error {
 	}
 	_ = json.Unmarshal(data, &x.Extensions)
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "name")
 	delete(x.Extensions, "url")
 	if len(x.Extensions) == 0 {

--- a/openapi3/link.go
+++ b/openapi3/link.go
@@ -69,6 +69,7 @@ func (link *Link) UnmarshalJSON(data []byte) error {
 	_ = json.Unmarshal(data, &x.Extensions)
 
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "operationRef")
 	delete(x.Extensions, "operationId")
 	delete(x.Extensions, "description")

--- a/openapi3/media_type.go
+++ b/openapi3/media_type.go
@@ -103,6 +103,7 @@ func (mediaType *MediaType) UnmarshalJSON(data []byte) error {
 	}
 	_ = json.Unmarshal(data, &x.Extensions)
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "schema")
 	delete(x.Extensions, "example")
 	delete(x.Extensions, "examples")

--- a/openapi3/openapi3.go
+++ b/openapi3/openapi3.go
@@ -116,6 +116,8 @@ func (doc *T) UnmarshalJSON(data []byte) error {
 	delete(x.Extensions, "servers")
 	delete(x.Extensions, "tags")
 	delete(x.Extensions, "externalDocs")
+	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	if len(x.Extensions) == 0 {
 		x.Extensions = nil
 	}

--- a/openapi3/operation.go
+++ b/openapi3/operation.go
@@ -118,6 +118,7 @@ func (operation *Operation) UnmarshalJSON(data []byte) error {
 	}
 	_ = json.Unmarshal(data, &x.Extensions)
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "tags")
 	delete(x.Extensions, "summary")
 	delete(x.Extensions, "description")

--- a/openapi3/origin.go
+++ b/openapi3/origin.go
@@ -42,3 +42,13 @@ func stripOriginFromAny(v any) any {
 		return v
 	}
 }
+
+// stripExtensionsOrigin removes __origin__ from every value in an extensions
+// map. Extension values are any-typed objects, so the YAML decoder injects
+// __origin__ into them. Without stripping it, two specs loaded from different
+// file paths would report spurious diffs in their extension values.
+func stripExtensionsOrigin(ext map[string]any) {
+	for k, v := range ext {
+		ext[k] = stripOriginFromAny(v)
+	}
+}

--- a/openapi3/origin_test.go
+++ b/openapi3/origin_test.go
@@ -517,6 +517,39 @@ components:
   line 0: mapping key "__origin__" already defined at line 17`, err.Error())
 }
 
+// TestOrigin_ExtensionValuesStripped verifies that __origin__ metadata injected
+// by the YAML decoder is not present in any-typed extension values.
+// Regression test: extension values that are YAML objects received __origin__
+// from the yaml3 decoder but it was never stripped, causing spurious diffs
+// between specs loaded from different file paths.
+func TestOrigin_ExtensionValuesStripped(t *testing.T) {
+	loader := NewLoader()
+
+	IncludeOrigin = true
+	defer unsetIncludeOrigin()
+
+	doc, err := loader.LoadFromFile("testdata/origin/extensions.yaml")
+	require.NoError(t, err)
+
+	val, ok := doc.Extensions["x-object-extension"]
+	require.True(t, ok, "x-object-extension must be present")
+
+	m, ok := val.(map[string]any)
+	require.True(t, ok, "x-object-extension value must be a map")
+
+	require.NotContains(t, m, originKey, "__origin__ must be stripped from extension object values")
+
+	// Also verify stripping works for a nested type (Info), covering the 20
+	// per-type UnmarshalJSON call sites with a single representative case.
+	infoVal, ok := doc.Info.Extensions["x-info-extension"]
+	require.True(t, ok, "x-info-extension must be present")
+
+	infoMap, ok := infoVal.(map[string]any)
+	require.True(t, ok, "x-info-extension value must be a map")
+
+	require.NotContains(t, infoMap, originKey, "__origin__ must be stripped from nested extension object values")
+}
+
 func TestOrigin_WithExternalRef(t *testing.T) {
 	loader := NewLoader()
 	loader.IsExternalRefsAllowed = true

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -218,6 +218,7 @@ func (parameter *Parameter) UnmarshalJSON(data []byte) error {
 	_ = json.Unmarshal(data, &x.Extensions)
 
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "name")
 	delete(x.Extensions, "in")
 	delete(x.Extensions, "description")

--- a/openapi3/path_item.go
+++ b/openapi3/path_item.go
@@ -100,6 +100,7 @@ func (pathItem *PathItem) UnmarshalJSON(data []byte) error {
 	}
 	_ = json.Unmarshal(data, &x.Extensions)
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "$ref")
 	delete(x.Extensions, "summary")
 	delete(x.Extensions, "description")

--- a/openapi3/request_body.go
+++ b/openapi3/request_body.go
@@ -110,6 +110,7 @@ func (requestBody *RequestBody) UnmarshalJSON(data []byte) error {
 	}
 	_ = json.Unmarshal(data, &x.Extensions)
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "description")
 	delete(x.Extensions, "required")
 	delete(x.Extensions, "content")

--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -174,6 +174,7 @@ func (response *Response) UnmarshalJSON(data []byte) error {
 	}
 	_ = json.Unmarshal(data, &x.Extensions)
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "description")
 	delete(x.Extensions, "headers")
 	delete(x.Extensions, "content")

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -414,6 +414,7 @@ func (schema *Schema) UnmarshalJSON(data []byte) error {
 	_ = json.Unmarshal(data, &x.Extensions)
 
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "oneOf")
 	delete(x.Extensions, "anyOf")
 	delete(x.Extensions, "allOf")

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -102,6 +102,7 @@ func (ss *SecurityScheme) UnmarshalJSON(data []byte) error {
 	}
 	_ = json.Unmarshal(data, &x.Extensions)
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "type")
 	delete(x.Extensions, "description")
 	delete(x.Extensions, "name")
@@ -274,6 +275,7 @@ func (flows *OAuthFlows) UnmarshalJSON(data []byte) error {
 	}
 	_ = json.Unmarshal(data, &x.Extensions)
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "implicit")
 	delete(x.Extensions, "password")
 	delete(x.Extensions, "clientCredentials")
@@ -366,6 +368,7 @@ func (flow *OAuthFlow) UnmarshalJSON(data []byte) error {
 	_ = json.Unmarshal(data, &x.Extensions)
 
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "authorizationUrl")
 	delete(x.Extensions, "tokenUrl")
 	delete(x.Extensions, "refreshUrl")

--- a/openapi3/server.go
+++ b/openapi3/server.go
@@ -116,6 +116,7 @@ func (server *Server) UnmarshalJSON(data []byte) error {
 	}
 	_ = json.Unmarshal(data, &x.Extensions)
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "url")
 	delete(x.Extensions, "description")
 	delete(x.Extensions, "variables")
@@ -288,6 +289,7 @@ func (serverVariable *ServerVariable) UnmarshalJSON(data []byte) error {
 	}
 	_ = json.Unmarshal(data, &x.Extensions)
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "enum")
 	delete(x.Extensions, "default")
 	delete(x.Extensions, "description")

--- a/openapi3/tag.go
+++ b/openapi3/tag.go
@@ -77,6 +77,7 @@ func (t *Tag) UnmarshalJSON(data []byte) error {
 	}
 	_ = json.Unmarshal(data, &x.Extensions)
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "name")
 	delete(x.Extensions, "description")
 	delete(x.Extensions, "externalDocs")

--- a/openapi3/testdata/origin/extensions.yaml
+++ b/openapi3/testdata/origin/extensions.yaml
@@ -1,0 +1,10 @@
+openapi: 3.0.1
+info:
+  title: Test API
+  version: v1
+  x-info-extension:
+    env: staging
+x-object-extension:
+  foo: bar
+  count: 42
+paths: {}

--- a/openapi3/xml.go
+++ b/openapi3/xml.go
@@ -60,6 +60,7 @@ func (xml *XML) UnmarshalJSON(data []byte) error {
 	}
 	_ = json.Unmarshal(data, &x.Extensions)
 	delete(x.Extensions, originKey)
+	stripExtensionsOrigin(x.Extensions)
 	delete(x.Extensions, "name")
 	delete(x.Extensions, "namespace")
 	delete(x.Extensions, "prefix")


### PR DESCRIPTION
## Summary

- Extension values are `map[string]any`, so the YAML decoder injects `__origin__` into them
- Without stripping it, two specs loaded from different file paths produce different extension values, causing spurious diffs when comparing otherwise identical extensions
- Adds `stripExtensionsOrigin` helper in `origin.go` and calls it after `delete(Extensions, originKey)` in all 21 `UnmarshalJSON` implementations, including the root `T` type

## Test plan

- [ ] `TestOrigin_ExtensionValuesStripped` — verifies `__origin__` is stripped from both root (`T`) and nested (`Info`) extension object values
- [ ] Full test suite passes: `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)