### PR TITLE
fix: bump yaml3+yaml to v0.0.9, add TestOrigin_WithExternalRefRootOrigin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0
 	github.com/gorilla/mux v1.8.0
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
-	github.com/oasdiff/yaml v0.0.8
-	github.com/oasdiff/yaml3 v0.0.8
+	github.com/oasdiff/yaml v0.0.9
+	github.com/oasdiff/yaml3 v0.0.9
 	github.com/perimeterx/marshmallow v1.1.5
 	github.com/stretchr/testify v1.9.0
 	github.com/woodsbury/decimal128 v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -18,10 +18,10 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
-github.com/oasdiff/yaml v0.0.8 h1:hFTw1c0jh59CK6+nYUGvWn0jQydMjVvek8AOvz/YDjQ=
-github.com/oasdiff/yaml v0.0.8/go.mod h1:7Z0Ludr7QQTB1bs7f3gKO7kRRdwdUXiPlGE7zgmUQgY=
-github.com/oasdiff/yaml3 v0.0.8 h1:ifhpCihBsP8cUK7Owj8qiPl8Nj0GFD290eg1do8in4E=
-github.com/oasdiff/yaml3 v0.0.8/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml v0.0.9 h1:zQOvd2UKoozsSsAknnWoDJlSK4lC0mpmjfDsfqNwX48=
+github.com/oasdiff/yaml v0.0.9/go.mod h1:8lvhgJG4xiKPj3HN5lDow4jZHPlx1i7dIwzkdAo6oAM=
+github.com/oasdiff/yaml3 v0.0.9 h1:rWPrKccrdUm8J0F3sGuU+fuh9+1K/RdJlWF7O/9yw2g=
+github.com/oasdiff/yaml3 v0.0.9/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/openapi3/origin_test.go
+++ b/openapi3/origin_test.go
@@ -567,6 +567,44 @@ func TestOrigin_WithExternalRef(t *testing.T) {
 		base.XML.Origin.Fields["prefix"])
 }
 
+// TestOrigin_WithExternalRefRootOrigin verifies that the root-level schema of an
+// externally $ref'd YAML file carries Origin metadata. Previously, only nested
+// schemas (values inside a parent mapping) received __origin__ injection; the
+// root mapping of a document was skipped. This test covers the fix in yaml3's
+// document() decoder that injects __origin__ for the root mapping too.
+func TestOrigin_WithExternalRefRootOrigin(t *testing.T) {
+	loader := NewLoader()
+	loader.IsExternalRefsAllowed = true
+	loader.IncludeOrigin = true
+	loader.Context = context.Background()
+
+	doc, err := loader.LoadFromFile("testdata/origin/external.yaml")
+	require.NoError(t, err)
+
+	// base is the root schema of external-schema.yaml ($ref resolved)
+	base := doc.Paths.Find("/subscribe").Post.RequestBody.Value.Content["application/json"].Schema.Value.Properties["name"].Value
+
+	// Root schema Origin must now be set (fixed in yaml3 document() injection)
+	require.NotNil(t, base.Origin)
+	require.Equal(t,
+		&Location{
+			File:   "testdata/origin/external-schema.yaml",
+			Line:   1,
+			Column: 1,
+			Name:   "",
+		},
+		base.Origin.Key)
+
+	require.Equal(t,
+		Location{
+			File:   "testdata/origin/external-schema.yaml",
+			Line:   1,
+			Column: 1,
+			Name:   "type",
+		},
+		base.Origin.Fields["type"])
+}
+
 // TestOrigin_MaplikeNoOriginKey verifies that __origin__ does not appear as a
 // map key in Responses, Paths, or Callback maplike types after loading.
 // The if k == originKey blocks in their UnmarshalJSON were removed; this


### PR DESCRIPTION
## Summary

- Bumps `yaml3` v0.0.8 → v0.0.9 and `yaml` v0.0.8 → v0.0.9
- Removes local `replace` directives used during development
- Adds `TestOrigin_WithExternalRefRootOrigin`: verifies that the root-level schema of an externally `$ref`'d YAML file now carries `Origin` metadata

## Background

Previously, `schema.Origin` was always `nil` for `$ref`-root schemas (e.g. `schemas/pet.yaml` directly defines a schema without a wrapping key). This meant source-tracking for checkers like `response-property-became-optional` returned no file/line info when the schema was in an external file. The yaml3 fix injects `__origin__` for the root mapping in `document()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)